### PR TITLE
Switch to Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     "monolog/monolog": "^1.22",
     "php": "^7.0",
     "psr/log": "^1.0",
-    "symfony/config": "^3.2",
-    "symfony/dependency-injection": "^3.2",
-    "symfony/yaml": "^3.2"
+    "symfony/config": "^4.0",
+    "symfony/dependency-injection": "^4.0",
+    "symfony/yaml": "^4.0"
   },
   "require-dev": {
   }

--- a/config/services.yml
+++ b/config/services.yml
@@ -1,8 +1,9 @@
 parameters:
-  logging_level: !php/const:Monolog\Logger::INFO
+  logging_level: !php/const Monolog\Logger::INFO
 
 services:
   logger:
+    public: true
     class: Monolog\Logger
     arguments:
       - 'handler'
@@ -26,6 +27,7 @@ services:
 
 # Define your own handlers and other services here
   handler.hello:
+    public: true
     class: Raines\Serverless\HelloHandler
 
 #  handler.example:


### PR DESCRIPTION
Since serverless-php is relatively new (it's more of a proof of concept), I suggest we require Symfony 4.0 minimum.